### PR TITLE
Manual full sync

### DIFF
--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       network:
-        description: 'Network to build for (mainnet, matic)'
+        description: 'Network to build for'
         required: true
         default: 'mainnet'
+        type: choice
+        options:
+        - mainnet
+        - arbitrum
+        - polygon
 
 jobs:
   deploy:

--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -1,0 +1,38 @@
+name: Manually Deploy Full Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to build for (mainnet, matic)'
+        required: true
+        default: 'mainnet'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: graph
+    env:
+      NETWORK: ${{ inputs.network }}
+      SUBGRAPH_NAME: "balancer-${{ inputs.network }}-v2-full"
+      CONFIG: "subgraph.${{ inputs.network }}.full.yaml"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets $NETWORK
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.12
+        with:
+          graph_access_token: ${{ secrets.GRAPH_ACCESS_TOKEN }}
+          graph_subgraph_name: $SUBGRAPH_NAME
+          graph_account: "balancer-labs"
+          graph_config_file: $CONFIG

--- a/scripts/generate-manifests.ts
+++ b/scripts/generate-manifests.ts
@@ -16,6 +16,12 @@ const generateManifests = async (): Promise<void> => {
       `subgraph${network === 'mainnet' ? '' : `.${network}`}.yaml`,
       Handlebars.compile(template)(config)
     );
+    // remove the graft info from the config
+    delete config.graft;
+    fs.writeFileSync(
+      `subgraph${network === 'mainnet' ? '' : `.${network}`}.full.yaml`,
+      Handlebars.compile(template)(config)
+    );    
   });
 
   // eslint-disable-next-line no-console

--- a/scripts/generate-manifests.ts
+++ b/scripts/generate-manifests.ts
@@ -19,7 +19,7 @@ const generateManifests = async (): Promise<void> => {
     // remove the graft info from the config
     delete config.graft;
     fs.writeFileSync(
-      `subgraph${network === 'mainnet' ? '' : `.${network}`}.full.yaml`,
+      `subgraph.${network}.full.yaml`,
       Handlebars.compile(template)(config)
     );    
   });


### PR DESCRIPTION
# Description

Adds logic to `generate-manifests` and a manually triggered workflow to deploy a full sync (non grafted) subgraph

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other